### PR TITLE
Improvement for Projectslist

### DIFF
--- a/application/modules/projectslist/controllers/Projectslist.php
+++ b/application/modules/projectslist/controllers/Projectslist.php
@@ -13,7 +13,7 @@ if (!defined('BASEPATH')) exit('No direct script access allowed');
 /**
  * Class Clients
  */
-class Clients extends Admin_Controller
+class Projectslist extends Admin_Controller
 {
     /**
      * Clients constructor.
@@ -27,8 +27,9 @@ class Clients extends Admin_Controller
 
     public function index()
     {
+        print_r("active");
         // Display active clients by default
-        redirect('projectlist/status/active');
+        redirect('projectslist/status/active');
     }
 
     /**
@@ -37,12 +38,17 @@ class Clients extends Admin_Controller
      */
     public function status($status = 'active', $page = 0)
     {
+
+        print_r("active");
+        die("die");
+
+
         if (is_numeric(array_search($status, array('active', 'inactive')))) {
             $function = 'is_' . $status;
             $this->mdl_clients->$function();
         }
 
-        $this->mdl_clients->with_total_balance()->paginate(site_url('projectlist/status/' . $status), $page);
+        $this->mdl_clients->with_total_balance()->paginate(site_url('projectslist/status/' . $status), $page);
         $clients = $this->mdl_clients->result();
 
         $this->layout->set(


### PR DESCRIPTION
So the trick was to rename projectslist.php to **P**rojectslist.php
also: the "redirect" in the "index" function was still to "projectlist", not "project**s**list"

Lots and lots of stuff to fix, since you took the Clients module as a base.

See this?
`print_r("active");`
you can also do:
```
print_r("active");
die("here i am");

that kills the script and that way you know where you are in the script


